### PR TITLE
Make carbon-kernel dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,8 @@
                     <reuseForks>true</reuseForks>
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging:pax-logging-api</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging:pax-logging-log4j2</classpathDependencyExclude>
                     </classpathDependencyExcludes>
                 </configuration>
             </plugin>
@@ -255,6 +257,12 @@
             <version>${carbon.kernel.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.wso2.carbon</groupId>
     <artifactId>org.wso2.carbon.securevault.aws</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <scm>
@@ -75,7 +75,7 @@
                             org.apache.http.pool;version="${httpcomponents-httpcore.osgi.version.range}",
                             org.apache.http.protocol;version="${httpcomponents-httpcore.osgi.version.range}",
 
-                            org.wso2.carbon.utils;version="${carbon.kernel.version.range}",
+                            org.wso2.carbon.utils;version="${carbon.kernel.version.range}";resolution:=optional,
                             org.wso2.securevault;version="${org.wso2.securevault.version.range}",
                             org.wso2.securevault.definition;version="${org.wso2.securevault.version.range}",
                             org.wso2.securevault.keystore;version="${org.wso2.securevault.version.range}",
@@ -198,10 +198,10 @@
         <project.scm.id>my-scm-server</project.scm.id>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-
+        <carbon.kernel.version>4.9.33</carbon.kernel.version>
         <carbon.kernel.version.range>[4.7.0,5.0.0)</carbon.kernel.version.range>
-
-        <org.wso2.securevault.version.range>[1.1.3,2.0.0)</org.wso2.securevault.version.range>
+        <org.wso2.securevault.version>1.1.17</org.wso2.securevault.version>
+        <org.wso2.securevault.version.range>[1.1.2,2.0.0)</org.wso2.securevault.version.range>
 
         <software.amazon.awssdk.version>2.28.0</software.amazon.awssdk.version>
         <software.amazon.awssdk.aws-crt-client.version>${software.amazon.awssdk.version}-PREVIEW</software.amazon.awssdk.aws-crt-client.version>
@@ -241,7 +241,7 @@
         <dependency>
             <groupId>org.wso2.securevault</groupId>
             <artifactId>org.wso2.securevault</artifactId>
-            <version>${org.wso2.securevault.version.range}</version>
+            <version>${org.wso2.securevault.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.ops4j.pax.logging</groupId>
@@ -252,7 +252,9 @@
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
-            <version>${carbon.kernel.version.range}</version>
+            <version>${carbon.kernel.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/org/wso2/carbon/securevault/aws/common/AWSVaultConstants.java
+++ b/src/main/java/org/wso2/carbon/securevault/aws/common/AWSVaultConstants.java
@@ -27,8 +27,35 @@ import java.io.File;
  */
 public class AWSVaultConstants {
 
-    public static final String CONFIG_FILE_PATH = CarbonUtils.getCarbonConfigDirPath() + File.separator
+    public static final String CONFIG_FILE_PATH = getCarbonConfigDirPath() + File.separator
             + "security" + File.separator + "secret-conf.properties";
+
+    /**
+     * Resolves the Carbon config directory path. Uses CarbonUtils.getCarbonConfigDirPath() when the
+     * carbon.utils bundle is available (optional OSGi dependency). Falls back to the "carbon.config.dir"
+     * system property for environments like Micro Integrator that run without Carbon Kernel.
+     *
+     * @return the Carbon config directory path.
+     * @throws IllegalStateException if neither CarbonUtils nor the system property is available.
+     */
+    private static String getCarbonConfigDirPath() {
+
+        try {
+            return CarbonUtils.getCarbonConfigDirPath();
+        } catch (NoClassDefFoundError e) {
+            String configDir = System.getProperty("carbon.config.dir");
+            if (configDir != null) {
+                configDir = configDir.trim();
+                if (!configDir.isEmpty()) {
+                    return configDir;
+                }
+            }
+            throw new IllegalStateException(
+                    "Cannot resolve Carbon config directory: carbon.utils bundle is not available " +
+                    "and 'carbon.config.dir' system property is not set.", e);
+        }
+    }
+
     public static final String IDENTITY_STORE_PASSWORD_ALIAS = "keystore.identity.store.alias";
     public static final String IDENTITY_KEY_PASSWORD_ALIAS = "keystore.identity.key.alias";
     public static final String COMMA = ",";

--- a/src/main/java/org/wso2/carbon/securevault/aws/common/AWSVaultConstants.java
+++ b/src/main/java/org/wso2/carbon/securevault/aws/common/AWSVaultConstants.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.securevault.aws.common;
 
-import org.wso2.carbon.utils.CarbonUtils;
-
 import java.io.File;
 
 /**
@@ -27,34 +25,8 @@ import java.io.File;
  */
 public class AWSVaultConstants {
 
-    public static final String CONFIG_FILE_PATH = getCarbonConfigDirPath() + File.separator
-            + "security" + File.separator + "secret-conf.properties";
-
-    /**
-     * Resolves the Carbon config directory path. Uses CarbonUtils.getCarbonConfigDirPath() when the
-     * carbon.utils bundle is available (optional OSGi dependency). Falls back to the "carbon.config.dir"
-     * system property for environments like Micro Integrator that run without Carbon Kernel.
-     *
-     * @return the Carbon config directory path.
-     * @throws IllegalStateException if neither CarbonUtils nor the system property is available.
-     */
-    private static String getCarbonConfigDirPath() {
-
-        try {
-            return CarbonUtils.getCarbonConfigDirPath();
-        } catch (NoClassDefFoundError e) {
-            String configDir = System.getProperty("carbon.config.dir");
-            if (configDir != null) {
-                configDir = configDir.trim();
-                if (!configDir.isEmpty()) {
-                    return configDir;
-                }
-            }
-            throw new IllegalStateException(
-                    "Cannot resolve Carbon config directory: carbon.utils bundle is not available " +
-                    "and 'carbon.config.dir' system property is not set.", e);
-        }
-    }
+    public static final String CONFIG_FILE_PATH = CarbonConfigResolver.getCarbonConfigDirPath()
+            + File.separator + "security" + File.separator + "secret-conf.properties";
 
     public static final String IDENTITY_STORE_PASSWORD_ALIAS = "keystore.identity.store.alias";
     public static final String IDENTITY_KEY_PASSWORD_ALIAS = "keystore.identity.key.alias";

--- a/src/main/java/org/wso2/carbon/securevault/aws/common/CarbonConfigResolver.java
+++ b/src/main/java/org/wso2/carbon/securevault/aws/common/CarbonConfigResolver.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.securevault.aws.common;
+
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Resolves the Carbon config directory path across different runtime environments.
+ */
+public class CarbonConfigResolver {
+
+    private CarbonConfigResolver() {
+
+    }
+
+    /**
+     * Returns the Carbon config directory path. Uses CarbonUtils.getCarbonConfigDirPath() when the
+     * carbon.utils bundle is available (optional OSGi dependency). Falls back to the "carbon.config.dir"
+     * system property for environments like Micro Integrator that run without Carbon Kernel.
+     *
+     * @return the Carbon config directory path.
+     * @throws IllegalStateException if neither CarbonUtils nor the system property is available.
+     */
+    public static String getCarbonConfigDirPath() {
+
+        try {
+            return CarbonUtils.getCarbonConfigDirPath();
+        } catch (NoClassDefFoundError e) {
+            String configDir = System.getProperty("carbon.config.dir");
+            if (configDir != null) {
+                configDir = configDir.trim();
+                if (!configDir.isEmpty()) {
+                    return configDir;
+                }
+            }
+            throw new IllegalStateException(
+                    "Cannot resolve Carbon config directory: carbon.utils bundle is not available " +
+                    "and 'carbon.config.dir' system property is not set.", e);
+        }
+    }
+}

--- a/src/test/java/org/wso2/carbon/securevault/aws/common/AWSVaultConstantsTest.java
+++ b/src/test/java/org/wso2/carbon/securevault/aws/common/AWSVaultConstantsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.securevault.aws.common;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.utils.CarbonUtils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Unit tests for the config-directory resolution logic in AWSVaultConstants.
+ */
+public class AWSVaultConstantsTest {
+
+    private static final String CONFIG_DIR_PROPERTY = "carbon.config.dir";
+    private static final String TEST_CONFIG_DIR = "/test/conf";
+
+    @BeforeClass
+    public void initAWSVaultConstants() {
+
+        // AWSVaultConstants.CONFIG_FILE_PATH is a static final evaluated once at class init.
+        // This access forces initialization now, before any test mocks are active, so that
+        // subsequent mocking of CarbonUtils cannot permanently corrupt the constant's value.
+        System.setProperty("carbon.home", System.getProperty("java.io.tmpdir"));
+        AWSVaultConstants.CONFIG_FILE_PATH.length();
+    }
+
+    @AfterClass
+    public void cleanUp() {
+
+        System.clearProperty("carbon.home");
+    }
+
+    @AfterMethod
+    public void clearSystemProperty() {
+
+        System.clearProperty(CONFIG_DIR_PROPERTY);
+    }
+
+    @Test(description = "When CarbonUtils is unavailable, the carbon.config.dir system property is used as fallback")
+    public void testFallbackToSystemPropertyWhenCarbonUtilsUnavailable() throws Exception {
+
+        System.setProperty(CONFIG_DIR_PROPERTY, TEST_CONFIG_DIR);
+
+        try (MockedStatic<CarbonUtils> carbonUtils = mockStatic(CarbonUtils.class)) {
+            carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
+                       .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
+
+            assertEquals(invokeCarbonConfigDirPath(), TEST_CONFIG_DIR);
+        }
+    }
+
+    @Test(description = "System property value with surrounding whitespace is trimmed before use")
+    public void testSystemPropertyValueIsTrimmed() throws Exception {
+
+        System.setProperty(CONFIG_DIR_PROPERTY, "  " + TEST_CONFIG_DIR + "  ");
+
+        try (MockedStatic<CarbonUtils> carbonUtils = mockStatic(CarbonUtils.class)) {
+            carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
+                       .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
+
+            assertEquals(invokeCarbonConfigDirPath(), TEST_CONFIG_DIR);
+        }
+    }
+
+    @Test(description = "When neither CarbonUtils nor system property is available, IllegalStateException is thrown")
+    public void testIllegalStateExceptionWhenNeitherSourceAvailable() throws Exception {
+
+        try (MockedStatic<CarbonUtils> carbonUtils = mockStatic(CarbonUtils.class)) {
+            carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
+                       .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
+
+            assertIllegalStateException();
+        }
+    }
+
+    @Test(description = "When CarbonUtils is unavailable and system property is blank, IllegalStateException is thrown")
+    public void testIllegalStateExceptionWhenSystemPropertyIsBlank() throws Exception {
+
+        System.setProperty(CONFIG_DIR_PROPERTY, "   ");
+
+        try (MockedStatic<CarbonUtils> carbonUtils = mockStatic(CarbonUtils.class)) {
+            carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
+                       .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
+
+            assertIllegalStateException();
+        }
+    }
+
+    private void assertIllegalStateException() throws Exception {
+
+        try {
+            invokeCarbonConfigDirPath();
+            fail("Expected IllegalStateException to be thrown");
+        } catch (InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof IllegalStateException,
+                    "Expected IllegalStateException but was: " + e.getCause().getClass().getName());
+        }
+    }
+
+    private String invokeCarbonConfigDirPath() throws Exception {
+
+        Method method = AWSVaultConstants.class.getDeclaredMethod("getCarbonConfigDirPath");
+        method.setAccessible(true);
+        return (String) method.invoke(null);
+    }
+}

--- a/src/test/java/org/wso2/carbon/securevault/aws/common/CarbonConfigResolverTest.java
+++ b/src/test/java/org/wso2/carbon/securevault/aws/common/CarbonConfigResolverTest.java
@@ -19,43 +19,20 @@
 package org.wso2.carbon.securevault.aws.common;
 
 import org.mockito.MockedStatic;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.utils.CarbonUtils;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 /**
- * Unit tests for the config-directory resolution logic in AWSVaultConstants.
+ * Unit tests for CarbonConfigResolver.
  */
-public class AWSVaultConstantsTest {
+public class CarbonConfigResolverTest {
 
     private static final String CONFIG_DIR_PROPERTY = "carbon.config.dir";
     private static final String TEST_CONFIG_DIR = "/test/conf";
-
-    @BeforeClass
-    public void initAWSVaultConstants() {
-
-        // AWSVaultConstants.CONFIG_FILE_PATH is a static final evaluated once at class init.
-        // This access forces initialization now, before any test mocks are active, so that
-        // subsequent mocking of CarbonUtils cannot permanently corrupt the constant's value.
-        System.setProperty("carbon.home", System.getProperty("java.io.tmpdir"));
-        AWSVaultConstants.CONFIG_FILE_PATH.length();
-    }
-
-    @AfterClass
-    public void cleanUp() {
-
-        System.clearProperty("carbon.home");
-    }
 
     @AfterMethod
     public void clearSystemProperty() {
@@ -64,7 +41,7 @@ public class AWSVaultConstantsTest {
     }
 
     @Test(description = "When CarbonUtils is unavailable, the carbon.config.dir system property is used as fallback")
-    public void testFallbackToSystemPropertyWhenCarbonUtilsUnavailable() throws Exception {
+    public void testFallbackToSystemPropertyWhenCarbonUtilsUnavailable() {
 
         System.setProperty(CONFIG_DIR_PROPERTY, TEST_CONFIG_DIR);
 
@@ -72,12 +49,12 @@ public class AWSVaultConstantsTest {
             carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
                        .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
 
-            assertEquals(invokeCarbonConfigDirPath(), TEST_CONFIG_DIR);
+            assertEquals(CarbonConfigResolver.getCarbonConfigDirPath(), TEST_CONFIG_DIR);
         }
     }
 
     @Test(description = "System property value with surrounding whitespace is trimmed before use")
-    public void testSystemPropertyValueIsTrimmed() throws Exception {
+    public void testSystemPropertyValueIsTrimmed() {
 
         System.setProperty(CONFIG_DIR_PROPERTY, "  " + TEST_CONFIG_DIR + "  ");
 
@@ -85,23 +62,25 @@ public class AWSVaultConstantsTest {
             carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
                        .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
 
-            assertEquals(invokeCarbonConfigDirPath(), TEST_CONFIG_DIR);
+            assertEquals(CarbonConfigResolver.getCarbonConfigDirPath(), TEST_CONFIG_DIR);
         }
     }
 
-    @Test(description = "When neither CarbonUtils nor system property is available, IllegalStateException is thrown")
-    public void testIllegalStateExceptionWhenNeitherSourceAvailable() throws Exception {
+    @Test(description = "When neither CarbonUtils nor system property is available, IllegalStateException is thrown",
+            expectedExceptions = IllegalStateException.class)
+    public void testIllegalStateExceptionWhenNeitherSourceAvailable() {
 
         try (MockedStatic<CarbonUtils> carbonUtils = mockStatic(CarbonUtils.class)) {
             carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
                        .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
 
-            assertIllegalStateException();
+            CarbonConfigResolver.getCarbonConfigDirPath();
         }
     }
 
-    @Test(description = "When CarbonUtils is unavailable and system property is blank, IllegalStateException is thrown")
-    public void testIllegalStateExceptionWhenSystemPropertyIsBlank() throws Exception {
+    @Test(description = "When CarbonUtils is unavailable and system property is blank, IllegalStateException is thrown",
+            expectedExceptions = IllegalStateException.class)
+    public void testIllegalStateExceptionWhenSystemPropertyIsBlank() {
 
         System.setProperty(CONFIG_DIR_PROPERTY, "   ");
 
@@ -109,25 +88,7 @@ public class AWSVaultConstantsTest {
             carbonUtils.when(CarbonUtils::getCarbonConfigDirPath)
                        .thenThrow(new NoClassDefFoundError("org/wso2/carbon/utils/CarbonUtils"));
 
-            assertIllegalStateException();
+            CarbonConfigResolver.getCarbonConfigDirPath();
         }
-    }
-
-    private void assertIllegalStateException() throws Exception {
-
-        try {
-            invokeCarbonConfigDirPath();
-            fail("Expected IllegalStateException to be thrown");
-        } catch (InvocationTargetException e) {
-            assertTrue(e.getCause() instanceof IllegalStateException,
-                    "Expected IllegalStateException but was: " + e.getCause().getClass().getName());
-        }
-    }
-
-    private String invokeCarbonConfigDirPath() throws Exception {
-
-        Method method = AWSVaultConstants.class.getDeclaredMethod("getCarbonConfigDirPath");
-        method.setAccessible(true);
-        return (String) method.invoke(null);
     }
 }

--- a/src/test/resources/testing.xml
+++ b/src/test/resources/testing.xml
@@ -22,6 +22,7 @@
     <test name="carbon-securevault-aws">
         <classes>
             <class name="org.wso2.carbon.securevault.aws.common.AWSSecretManagerClientTest"/>
+            <class name="org.wso2.carbon.securevault.aws.common.AWSVaultConstantsTest"/>
             <class name="org.wso2.carbon.securevault.aws.common.AWSVaultUtilsTest"/>
             <class name="org.wso2.carbon.securevault.aws.secret.handler.AWSSecretCallbackHandlerTest"/>
             <class name="org.wso2.carbon.securevault.aws.secret.repository.AWSSecretRepositoryTest"/>

--- a/src/test/resources/testing.xml
+++ b/src/test/resources/testing.xml
@@ -22,7 +22,7 @@
     <test name="carbon-securevault-aws">
         <classes>
             <class name="org.wso2.carbon.securevault.aws.common.AWSSecretManagerClientTest"/>
-            <class name="org.wso2.carbon.securevault.aws.common.AWSVaultConstantsTest"/>
+            <class name="org.wso2.carbon.securevault.aws.common.CarbonConfigResolverTest"/>
             <class name="org.wso2.carbon.securevault.aws.common.AWSVaultUtilsTest"/>
             <class name="org.wso2.carbon.securevault.aws.secret.handler.AWSSecretCallbackHandlerTest"/>
             <class name="org.wso2.carbon.securevault.aws.secret.repository.AWSSecretRepositoryTest"/>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This is to support products like Micro Integrator without a kernel. Currently, carbon-kernel dependency is used only to read config.dir constant. This can be read from the system property as well. This PR brings an improvement to bring the system property as a fallback option.

As part of the effort, strict dependency versions are used for compilations since the latest carbon-kernel and secure vault dependencies are built with JDK 21 and not compatible with this repo's build. Since this extension has to work across multiple product versions, the repo has to be built using a lower JDK version.

